### PR TITLE
Add support for naming migrations from file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = false
+max_line_length = 120
+tab_width = 4
+
+[{*.go, *.go2}]
+indent_style = tab

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Ok. See [example_migratedir_test.go](example_migratedir_test.go).
 ms, err := pgutil.MigrationsInDir(fsys, "path/to/migrations")
 ```
 
+To name a migration filr, add a comment anywhere in the file like this:
+
+```postgresql
+-- Migration name: custom_migration_name
+```
+
+Migrations are still executed in filename order.
+
 ## Utilities
 
 ### Transaction

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Ok. See [example_migratedir_test.go](example_migratedir_test.go).
 ms, err := pgutil.MigrationsInDir(fsys, "path/to/migrations")
 ```
 
-To name a migration filr, add a comment anywhere in the file like this:
+Migrations from file use the filename as the migration name. To set a name, add a comment anywhere in the file like this:
 
 ```postgresql
 -- Migration name: custom_migration_name

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module pkg.iterate.no/pgutil
 go 1.16
 
 require (
-	github.com/cenkalti/backoff/v4 v4.1.1 // indirect
+	github.com/cenkalti/backoff/v4 v4.1.1
 	github.com/jackc/pgx/v4 v4.11.0
 	github.com/ory/dockertest/v3 v3.6.5
 )

--- a/migrate.go
+++ b/migrate.go
@@ -21,7 +21,7 @@ const lockKey = 3628
 // back.
 type Migration func(context.Context, *sql.Tx) error
 
-var migrationName = regexp.MustCompile(`(?i)^[ \t]*--[ \t]*migration name:\s*(\w+(?: *[\w]+)*)\s*$`)
+var migrationName = regexp.MustCompile(`(?i)^[\t ]*-- Migration name: (\w+)$`)
 
 // Migrate migrates the database to the current version.
 func Migrate(ctx context.Context, db *sql.DB, ms ...Migration) error {

--- a/migrate.go
+++ b/migrate.go
@@ -1,12 +1,15 @@
 package pgutil
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"database/sql"
 	"fmt"
+	"io"
 	"io/fs"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"time"
 )
@@ -17,6 +20,8 @@ const lockKey = 3628
 // Migration is a database migration. If it returns err, the transaction rolls
 // back.
 type Migration func(context.Context, *sql.Tx) error
+
+var migrationName = regexp.MustCompile(`(?i)^[ \t]*--[ \t]*migration name:\s*(\w+(?: *[\w]+)*)\s*$`)
 
 // Migrate migrates the database to the current version.
 func Migrate(ctx context.Context, db *sql.DB, ms ...Migration) error {
@@ -115,22 +120,58 @@ func MigrationsInDir(fsys fs.ReadDirFS, dirname string) ([]Migration, error) {
 	return ms, nil
 }
 
+// getMigrationName attempts to determine the name of the migration.
+func getMigrationName(fsys fs.FS, pathname string) (string, error) {
+	// scan for a migration name
+	f, err := fsys.Open(pathname)
+	if err != nil {
+		return pathname, err
+	}
+	if n := matchMigrationName(f); n != "" {
+		return n, nil
+	}
+	defer f.Close()
+
+	// grab filename
+	s, err := f.Stat()
+	if err != nil {
+		return "", fmt.Errorf("failed to stat file: %w", err)
+	}
+	n := s.Name()
+
+	return n, nil
+}
+
+// matchMigrationName attempts to find a migration name in the migration file.
+func matchMigrationName(f io.Reader) string {
+	b := bufio.NewScanner(f)
+
+	for b.Scan() {
+		bs := b.Bytes()
+		locs := migrationName.FindSubmatchIndex(bs)
+		if len(locs) == 4 {
+			n := bs[locs[2]:locs[3]]
+			return string(n)
+		}
+	}
+
+	return ""
+}
+
 // migrationFromFile creates a Migration from a file in an fs.FS.
 func migrationFromFile(fsys fs.FS, pathname string) Migration {
 	return func(ctx context.Context, tx *sql.Tx) error {
+		n, err := getMigrationName(fsys, pathname)
+		if err != nil {
+			return fmt.Errorf("could not read migration name: %v", err)
+		}
+
 		f, err := fsys.Open(pathname)
 		if err != nil {
 			return fmt.Errorf("opening migration: %w", err)
 		}
 
 		defer f.Close()
-
-		// grab filename
-		s, err := f.Stat()
-		if err != nil {
-			return fmt.Errorf("failed to stat file: %w", err)
-		}
-		n := s.Name()
 
 		if ok, err := IsMigrated(ctx, tx, n); err != nil {
 			return fmt.Errorf("checking migration state: %w", err)

--- a/testdata/migrations_in_dir/multiple_ops.sql
+++ b/testdata/migrations_in_dir/multiple_ops.sql
@@ -1,3 +1,5 @@
+-- Migration name: custom_migration_name
+
 CREATE TABLE my_table
 (
     id        UUID PRIMARY KEY,


### PR DESCRIPTION
I want to move some migrations from code to file, but I need to both avoid them being executed multiple times, and to preserve order. Eg., to prevent `create_person_table` from running again when the migration file `01-person.sql` is committed, I propose the following:

If the case insensitive comment `^[\t ]*-- Migration name: (\w+)$` appears in migration, the migration is named as specified. Migrations are still ordered by filename.